### PR TITLE
Added _total to GET /channels/:channel/follows

### DIFF
--- a/v3_resources/follows.md
+++ b/v3_resources/follows.md
@@ -64,6 +64,7 @@ curl -H 'Accept: application/vnd.twitchtv.v3+json' \
 
 ```json
 {
+  "_total": 1234,
   "_links": {
     "next": "https://api.twitch.tv/kraken/channels/test_user1/follows?direction=DESC&limit=25&offset=25",
     "self": "https://api.twitch.tv/kraken/channels/test_user1/follows?direction=DESC&limit=25&offset=0"


### PR DESCRIPTION
`_total` is not included in the example for GET /channels/:channel/follows but is present in a real response.
