### PR TITLE
Added missing `initial_time` video parameter

### DIFF
--- a/embedding.md
+++ b/embedding.md
@@ -61,6 +61,7 @@ Here are the embed codes and parameters you might need to integrate streams, vid
 - `channel` : Channel that video belongs to.
 - `chapter_id` : Chapter ID of the video.
 - `volume`  : Player volume ranging from 0 to 50. Default is 25.
+- `initial_time` : Start time in seconds.
 
 #### Code
 


### PR DESCRIPTION
This parameter was missing from the documentation.
