### PR TITLE
Fix malformed JSON example in /chats/emoticons

### DIFF
--- a/v3_resources/chat.md
+++ b/v3_resources/chat.md
@@ -51,7 +51,7 @@ curl -H 'Accept: application/vnd.twitchtv.v3+json' \
 {
   "_links": {
     "self": "https://api.twitch.tv/kraken/chat/emoticons"
-  }
+  },
   "emoticons": [
     {
       "regex": "\:-?\(",


### PR DESCRIPTION
Noticed a missing comma while running a unit test.
