### PR TITLE
Update Readme example to use Client-ID header

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ application/json
 
 Specify a specific version (v2):
 
-    curl -i -H 'Accept: application/vnd.twitchtv.v2+json' 'https://api.twitch.tv/kraken/channels/hebo?client_id=axjhfp777tflhy0yjb5sftsil' 
+    curl -i -H 'Accept: application/vnd.twitchtv.v2+json'\
+    -H 'Client-ID: axjhfp777tflhy0yjb5sftsil'\
+    'https://api.twitch.tv/kraken/channels/hebo' 
     
     HTTP/1.1 200 OK
     ...


### PR DESCRIPTION
Previously, the API was promoting the use of the client_id GET parameter in requests. This is functional for all requests, but `/streams`, which is a unique query parameter for that endpoint. In order to mitigate headaches for newcomers, I have updated the example to reflect a standard request with the Client-ID HTTP header as the preferred method. This is the recommended approach lower in the README under _Rate Limits_.

This is related to issue #281.
