### PR TITLE
Not Verified Email addresses

### DIFF
--- a/v2_resources/users.md
+++ b/v2_resources/users.md
@@ -44,6 +44,7 @@ curl -H 'Accept: application/vnd.twitchtv.v2+json' \
 ## `GET /user`
 
 Returns a user object.
+If the user's Twitch registered Email Address is not verified, 'null' will be returned.
 
 *__Authenticated__*, required scope: `user_read`
 

--- a/v2_resources/users.md
+++ b/v2_resources/users.md
@@ -47,7 +47,7 @@ Returns a user object.
 
 *__Authenticated__*, required scope: `user_read`
 
-*__Gotcha__* If the user's Twitch registered Email Address is not verified, 'null' will be returned.
+*__Gotcha__* If the user's Twitch registered Email Address is not verified, `null` will be returned.
 
 ### Example Request
 

--- a/v2_resources/users.md
+++ b/v2_resources/users.md
@@ -44,9 +44,10 @@ curl -H 'Accept: application/vnd.twitchtv.v2+json' \
 ## `GET /user`
 
 Returns a user object.
-If the user's Twitch registered Email Address is not verified, 'null' will be returned.
 
 *__Authenticated__*, required scope: `user_read`
+
+*__Gotcha__* If the user's Twitch registered Email Address is not verified, 'null' will be returned.
 
 ### Example Request
 

--- a/v3_resources/users.md
+++ b/v3_resources/users.md
@@ -46,9 +46,10 @@ curl -H 'Accept: application/vnd.twitchtv.v3+json' \
 ## `GET /user`
 
 Returns a user object.
-If the user's Twitch registered Email Address is not verified, 'null' will be returned.
 
 *__Authenticated__*, required scope: `user_read`
+
+*__Gotcha__* If the user's Twitch registered Email Address is not verified, 'null' will be returned.
 
 ### Example Request
 

--- a/v3_resources/users.md
+++ b/v3_resources/users.md
@@ -49,7 +49,7 @@ Returns a user object.
 
 *__Authenticated__*, required scope: `user_read`
 
-*__Gotcha__* If the user's Twitch registered Email Address is not verified, 'null' will be returned.
+*__Gotcha__* If the user's Twitch registered Email Address is not verified, `null` will be returned.
 
 ### Example Request
 

--- a/v3_resources/users.md
+++ b/v3_resources/users.md
@@ -46,6 +46,7 @@ curl -H 'Accept: application/vnd.twitchtv.v3+json' \
 ## `GET /user`
 
 Returns a user object.
+If the user's Twitch registered Email Address is not verified, 'null' will be returned.
 
 *__Authenticated__*, required scope: `user_read`
 


### PR DESCRIPTION
Thought it might be useful to add a note about what is returned when a given authenticated user with user_read scope has not verified their email address.