### PR TITLE
Blocks typo fix

### DIFF
--- a/v3_resources/blocks.md
+++ b/v3_resources/blocks.md
@@ -4,7 +4,7 @@ Stores and updates information about a [user's][users] block list.
 
 | Endpoint | Description |
 | ---- | --------------- |
-| [GET /users/:login/blocks](/v3_resources/blocks.md#get-usersloginblocks) | Get user's block list |
+| [GET /users/:user/blocks](/v3_resources/blocks.md#get-usersloginblocks) | Get user's block list |
 | [PUT /users/:user/blocks/:target](/v3_resources/blocks.md#put-usersuserblockstarget) | Add target to user's block list |
 | [DELETE /users/:user/blocks/:target](/v3_resources/blocks.md#delete-usersuserblockstarget) | Delete target from user's block list |
 

--- a/v3_resources/blocks.md
+++ b/v3_resources/blocks.md
@@ -10,9 +10,9 @@ Stores and updates information about a [user's][users] block list.
 
 [users]: /v3_resources/users.md
 
-## `GET /users/:login/blocks`
+## `GET /users/:user/blocks`
 
-Returns a list of blocks objects on `:login`'s block list. List sorted by recency, newest first.
+Returns a list of blocks objects on `:user`'s block list. List sorted by recency, newest first.
 
 *__Authenticated__*, required scope: `user_blocks_read`
 


### PR DESCRIPTION
For document consistency, I think using `:user` instead of `:login` for the `GET /users/:user/blocks` makes more sense.