### PR TITLE
Added error message for `PUT /channels/:channel`

### DIFF
--- a/v3_resources/channels.md
+++ b/v3_resources/channels.md
@@ -270,6 +270,10 @@ curl -H 'Accept: application/vnd.twitchtv.v3+json' -H 'Authorization: OAuth <acc
 }
 ```
 
+### Errors
+
+`422 Unprocessable Entity` if trying to set `delay` for a channel that is not partnered.
+
 ## `DELETE /channels/:channel/stream_key`
 
 Resets channel's stream key.


### PR DESCRIPTION
`422 Unprocessable Entity` is returned when trying to set the `delay` of a channel that is not partnered. Added this fact to the documentation.