### PR TITLE
Fix response of `DELETE /channels/:channel/stream_key`

### DIFF
--- a/v3_resources/channels.md
+++ b/v3_resources/channels.md
@@ -289,7 +289,45 @@ curl -H 'Accept: application/vnd.twitchtv.v3+json' -H 'Authorization: OAuth <acc
 
 ### Example Response
 
-`204 No Content`.
+```json
+{
+  "mature": false,
+  "status": "test status",
+  "broadcaster_language": "en",
+  "display_name": "test_channel",
+  "game": "Gaming Talk Shows",
+  "delay": 0,
+  "language": "en",
+  "_id": 12345,
+  "name": "test_channel",
+  "created_at": "2007-05-22T10:39:54Z",
+  "updated_at": "2015-02-12T04:15:49Z",
+  "logo": "http://static-cdn.jtvnw.net/jtv_user_pictures/test_channel-profile_image-94a42b3a13c31c02-300x300.jpeg",
+  "banner": "http://static-cdn.jtvnw.net/jtv_user_pictures/test_channel-channel_header_image-08dd874c17f39837-640x125.png",
+  "video_banner": "http://static-cdn.jtvnw.net/jtv_user_pictures/test_channel-channel_offline_image-b314c834d210dc1a-640x360.png",
+  "background": null,
+  "profile_banner": "http://static-cdn.jtvnw.net/jtv_user_pictures/test_channel-profile_banner-6936c61353e4aeed-480.png",
+  "profile_banner_background_color": "null",
+  "partner": true,
+  "url": "http://www.twitch.tv/test_channel",
+  "views": 49144894,
+  "followers": 215780,
+  "_links": {
+    "self": "https://api.twitch.tv/kraken/channels/test_channel",
+    "follows": "https://api.twitch.tv/kraken/channels/test_channel/follows",
+    "commercial": "https://api.twitch.tv/kraken/channels/test_channel/commercial",
+    "stream_key": "https://api.twitch.tv/kraken/channels/test_channel/stream_key",
+    "chat": "https://api.twitch.tv/kraken/chat/test_channel",
+    "features": "https://api.twitch.tv/kraken/channels/test_channel/features",
+    "subscriptions": "https://api.twitch.tv/kraken/channels/test_channel/subscriptions",
+    "editors": "https://api.twitch.tv/kraken/channels/test_channel/editors",
+    "teams": "https://api.twitch.tv/kraken/channels/test_channel/teams",
+    "videos": "https://api.twitch.tv/kraken/channels/test_channel/videos"
+  },
+  "email": "test_channel@twitch.tv",
+  "stream_key": "live_5439587_s8df7s9d7g6dsfggsdfg"
+}
+```
 
 ## `POST /channels/:channel/commercial`
 


### PR DESCRIPTION
It appears `DELETE /channels/:channel/stream_key` responds with the `channel` object containing the new `stream_key` rather than a `204 No Content`