### PR TITLE
Fix channels errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ We use an OAuth 2.0, an authentication protocol designed to make accessing user 
 | ---- | --------------- |
 | [GET /channels/:channel](/v3_resources/channels.md#get-channelschannel) | Get channel object|
 | [GET /channel](/v3_resources/channels.md#get-channel) | Get channel object |
-| [GET /channels/:channel/editors](/v3_resources/channels.md#get-channelschanneleditors) | Get channel's list of editors |
-| [PUT /channels/:channel](/v3_resources/channels.md#put-channelschannel) | Update channel object |
 | [GET /channels/:channel/videos](/v3_resources/channels.md#get-channelschannelvideos) | Get channel's list of videos |
 | [GET /channels/:channel/follows](/v3_resources/channels.md#get-channelschannelfollows) | Get channel's list of following users |
+| [GET /channels/:channel/editors](/v3_resources/channels.md#get-channelschanneleditors) | Get channel's list of editors |
+| [PUT /channels/:channel](/v3_resources/channels.md#put-channelschannel) | Update channel object |
 | [DELETE /channels/:channel/stream_key](/v3_resources/channels.md#delete-channelschannelstream_key) | Reset channel's stream key |
 | [POST /channels/:channel/commercial](/v3_resources/channels.md#post-channelschannelcommercial) | Start a commercial on channel |
 | [GET /channels/:channel/teams](/v3_resources/channels.md#get-channelschannelteams) | Get list of teams channel belongs to |

--- a/v3_resources/channels.md
+++ b/v3_resources/channels.md
@@ -6,10 +6,10 @@ Channels serve as the home location for a [user's][users] content. Channels have
 | ---- | --------------- |
 | [GET /channels/:channel](/v3_resources/channels.md#get-channelschannel) | Get channel object|
 | [GET /channel](/v3_resources/channels.md#get-channel) | Get channel object |
-| [GET /channels/:channel/editors](/v3_resources/channels.md#get-channelschanneleditors) | Get channel's list of editors |
-| [PUT /channels/:channel](/v3_resources/channels.md#put-channelschannel) | Update channel object |
 | [GET /channels/:channel/videos](/v3_resources/channels.md#get-channelschannelvideos) | Get channel's list of videos |
 | [GET /channels/:channel/follows](/v3_resources/channels.md#get-channelschannelfollows) | Get channel's list of following users |
+| [GET /channels/:channel/editors](/v3_resources/channels.md#get-channelschanneleditors) | Get channel's list of editors |
+| [PUT /channels/:channel](/v3_resources/channels.md#put-channelschannel) | Update channel object |
 | [DELETE /channels/:channel/stream_key](/v3_resources/channels.md#delete-channelschannelstream_key) | Reset channel's stream key |
 | [POST /channels/:channel/commercial](/v3_resources/channels.md#post-channelschannelcommercial) | Start a commercial on channel |
 | [GET /channels/:channel/teams](/v3_resources/channels.md#get-channelschannelteams) | Get list of teams channel belongs to |

--- a/v3_resources/channels.md
+++ b/v3_resources/channels.md
@@ -126,11 +126,11 @@ curl -H 'Accept: application/vnd.twitchtv.v3+json' -H 'Authorization: OAuth <acc
 
 ## `GET /channels/:channel/videos`
 
-See the [Videos](https://github.com/justintv/Twitch-API/wiki/Videos-Resource#wiki-videos-channel) resource.
+See the [Videos](videos.md#get-channelschannelvideos) resource.
 
 ## `GET /channels/:channel/follows`
 
-See the [Follows](follows.md#get-a-channels-list-of-followers-) resource.
+See the [Follows](follows.md#get-channelschannelfollows) resource.
 
 ## `GET /channels/:channel/editors`
 


### PR DESCRIPTION
Fixed the endpoint summary order in `channels.md` so it matches the order of the info in the file. Also, the links to the `Videos` and `Follows` resources incorrectly pointed to the wiki or had wring fragment identifiers.