### PR TITLE
Fix doc errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ We use an OAuth 2.0, an authentication protocol designed to make accessing user 
 
 | Endpoint | Description |
 | ---- | --------------- |
-| [GET /users/:login/blocks](/v3_resources/blocks.md#get-usersloginblocks) | Get user's block list |
+| [GET /users/:user/blocks](/v3_resources/blocks.md#get-usersloginblocks) | Get user's block list |
 | [PUT /users/:user/blocks/:target](/v3_resources/blocks.md#put-usersuserblockstarget) | Add target to user's block list |
 | [DELETE /users/:user/blocks/:target](/v3_resources/blocks.md#delete-usersuserblockstarget) | Delete target from user's block list |
 

--- a/v3_resources/search.md
+++ b/v3_resources/search.md
@@ -164,6 +164,7 @@ curl -H 'Accept: application/vnd.twitchtv.v3+json' \
 
 ```json
 {
+  "_total": 76,
   "_links": {
     "self": "https://api.twitch.tv/kraken/search/streams?limit=25&offset=0&q=starcraft",
     "next": "https://api.twitch.tv/kraken/search/streams?limit=25&offset=25&q=starcraft"

--- a/v3_resources/streams.md
+++ b/v3_resources/streams.md
@@ -356,18 +356,6 @@ Returns a summary of current streams.
             <td>string</td>
             <td>Only show stats for the set game</td>
         </tr>
-        <tr>
-            <td><code>limit</code></td>
-            <td>optional</td>
-            <td>integer</td>
-            <td>Maximum number of objects in array. Default is 25. Maximum is 100.</td>
-        </tr>
-        <tr>
-            <td><code>offset</code></td>
-            <td>optional</td>
-            <td>integer</td>
-            <td>Object offset for pagination. Default is 0.</td>
-        </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
The `GET /streams/summary` documentation lists 2 parameters (`limit` and `offset`) which _appear_ to not be applicable for that endpoint. I removed those parameters as well as fixed 2 minor typos.