### PR TITLE
deprecated tags removed

### DIFF
--- a/chat/capabilities.md
+++ b/chat/capabilities.md
@@ -68,13 +68,13 @@ Use with tags CAP to get anything out of it. See USERSTATE tags below as it does
     < CAP REQ :twitch.tv/tags
     > :tmi.twitch.tv CAP * ACK :twitch.tv/tags
 
-Adds IRC v3 message tags to `PRIVMSG` and `USERSTATE` (if enabled with commands CAP)
+Adds IRC v3 message tags to `PRIVMSG`, `USERSTATE`, `NOTICE` and `GLOBALUSERSTATE` (if enabled with commands CAP)
 
 ### PRIVMSG
 
 Example message:
 
-    @color=#1E0ACC;display-name=3ventic;emotes=25:0-4,12-16/1902:6-10;subscriber=0;turbo=1;user-type=mod;user_type=mod :3ventic!3ventic@3ventic.tmi.twitch.tv PRIVMSG #gophergaming :Kappa Keepo Kappa
+    @color=#0D4200;display-name=3ventic;emotes=25:0-4,12-16/1902:6-10;subscriber=0;turbo=1;user-type=global_mod :3ventic!3ventic@3ventic.tmi.twitch.tv PRIVMSG #3ventic :Kappa Keepo Kappa
 
 - `color` is hexadecimal RGB color code, which *can be empty* if the user never set it.
 - `display-name` is the user's display name, escaped as described [as described in the IRCv3 spec](http://ircv3.net/specs/core/message-tags-3.2.html). Empty if it's never been set.
@@ -83,20 +83,17 @@ Example message:
   - `emote_id` is the number to use in this URL: `http://static-cdn.jtvnw.net/emoticons/v1/:emote_id/:size` (size is 1.0, 2.0 or 3.0)
   - Emote indexes are simply character indexes. `\001ACTION ` does *not* count and indexing starts from the first character that is part of the user's "actual message". In the example message, the first Kappa (emote id 25) is from character 0 (K) to character 4 (a), and the other Kappa is from 12 to 16.
 - `subscriber`and `turbo` are either 0 or 1 depending on whether the user has sub or turbo badge or not.
-- `user-type` is either *empty*, `mod`, `global_mod`, `admin` or `staff`. The broadcaster can have any of these.
-- `user_type` is deprecated and will be removed soon. Use `user-type` instead.
+- `user-type` is either *empty*, `mod`, `global_mod`, `admin` or `staff`. The broadcaster can have any of these including empty.
 
 ### USERSTATE
 
 USERSTATE is sent when joining a channel and every time you send a PRIVMSG to a channel. Example:
 
-    @color=#1E0ACC;display-name=3ventic;emote-sets=0,12239,2126,237,33,366,4578,469,793,9400;emotesets=0,12239,2126,237,33,366,4578,469,793,9400;subscriber=0;turbo=1;user-type=mod;user_type=mod :tmi.twitch.tv USERSTATE #gophergaming
+    @color=#0D4200;display-name=3ventic;emote-sets=0,33,50,237,793,2126,3517,4578,5569,9400,10337,12239;subscriber=0;turbo=1;user-type=global_mod :tmi.twitch.tv USERSTATE #3ventic
 
 The tags shared with PRIVMSG work exactly the same.
 
 `emote-sets` contains your emote set, which you can use to request `https://api.twitch.tv/kraken/chat/emoticon_images?emotesets=[straight from the emote-sets tag]`. Always contains at least 0.
-
-`emotesets` is deprecated and will be removed soon. Use `emote-sets` instead.
 
 ### GLOBALUSERSTATE
 


### PR DESCRIPTION
Removed the deprecated tags that have now been removed and updated the examples. Emphasized that broadcaster's user-type can be empty.