### PR TITLE
IRC.md AWS, room-id

### DIFF
--- a/IRC.md
+++ b/IRC.md
@@ -11,8 +11,7 @@ Lines prefixed with < are sent from client to server, and lines prefixed with > 
 You can connect to Twitch IRC using the following bits of information:
 
 - The server name to connect to is: `irc.chat.twitch.tv`.
-- The port to connect to is `6667`
-- **SSL is not currently supported for Twitch IRC**
+- The port to connect to is `6667`, or `6697` for SSL.
 - Your nickname must be your Twitch username in lowercase.
 - Your password should be an OAuth token [authorized through our API](/authentication.md) with the `chat_login` scope.
   - The token must have the prefix of `oauth:`. For example, if you have the token `abcd`, you send `oauth:abcd`.

--- a/IRC.md
+++ b/IRC.md
@@ -63,7 +63,7 @@ A brief list of commands supported by our IRC server include:
 
 **JOIN** *#channel*
 
-Note: After a successful `JOIN`, you will *not* receive a membership state events (`NAMES`, `JOIN`, `PART`, or `MODE`) *unless* you've requested our [IRCv3 `Membership`](#membership) capability
+Note: After a successful `JOIN`, you will *not* receive a membership state events (`NAMES`, `JOIN`, `PART`, or `MODE`) *unless* you've requested our [IRCv3 `Membership`](#membership) capability. The channel name should be entered in lowercase.
 
 ```
 < JOIN #channel

--- a/IRC.md
+++ b/IRC.md
@@ -10,7 +10,7 @@ Lines prefixed with < are sent from client to server, and lines prefixed with > 
 
 You can connect to Twitch IRC using the following bits of information:
 
-- The server name to connect to is: `irc.chat.twitch.tv`.
+- The server name to connect to is: `irc.twitch.tv`.
 - The port to connect to is `6667`, or `6697` for SSL.
 - Your nickname must be your Twitch username in lowercase.
 - Your password should be an OAuth token [authorized through our API](/authentication.md) with the `chat_login` scope.

--- a/IRC.md
+++ b/IRC.md
@@ -226,7 +226,7 @@ Adds IRC v3 message tags to `PRIVMSG`, `USERSTATE`, `NOTICE` and `GLOBALUSERSTAT
 Example message:
 
 ```
-> @color=#0D4200;display-name=TWITCH_UserNaME;emotes=25:0-4,12-16/1902:6-10;mod=0;subscriber=0;turbo=1;user-id=1337;user-type=global_mod :twitch_username!twitch_username@twitch_username.tmi.twitch.tv PRIVMSG #channel :Kappa Keepo Kappa
+> @color=#0D4200;display-name=TWITCH_UserNaME;emotes=25:0-4,12-16/1902:6-10;mod=0;room-id=1337;subscriber=0;turbo=1;user-id=1337;user-type=global_mod :twitch_username!twitch_username@twitch_username.tmi.twitch.tv PRIVMSG #channel :Kappa Keepo Kappa
 ```
 
 - `color` is a hexadecimal RGB color code
@@ -238,6 +238,7 @@ Example message:
   - `emote_id` is the number to use in this URL: `http://static-cdn.jtvnw.net/emoticons/v1/:emote_id/:size` (size is 1.0, 2.0 or 3.0)
   - Emote indexes are simply character indexes. `\001ACTION ` does *not* count and indexing starts from the first character that is part of the user's "actual message". In the example message, the first Kappa (emote id 25) is from character 0 (K) to character 4 (a), and the other Kappa is from 12 to 16.
 - `mod`, `subscriber` and `turbo` are either 0 or 1 depending on whether the user has mod, sub or turbo badge or not.
+- `room-id` is the ID of the channel.
 - `user-id` is the user's ID.
 - `user-type` is either *empty*, `mod`, `global_mod`, `admin` or `staff`.
   - The broadcaster can have any of these, including empty.

--- a/IRC.md
+++ b/IRC.md
@@ -10,7 +10,7 @@ Lines prefixed with < are sent from client to server, and lines prefixed with > 
 
 You can connect to Twitch IRC using the following bits of information:
 
-- The server name to connect to is: `irc.twitch.tv`.
+- The server name to connect to is: `irc.chat.twitch.tv`.
 - The port to connect to is `6667`
 - **SSL is not currently supported for Twitch IRC**
 - Your nickname must be your Twitch username in lowercase.


### PR DESCRIPTION
Update IRC.md to the new information coming with the move to AWS cluster.

Added information about the new `room-id` tag for PRIVMSG and a note that channel name should be in all-lowercase for `JOIN`.

It is probably for the best if this PR is not applied until the majority of channels are on AWS.