### PR TITLE
Room ID, case-sensitivity and streams language param

### DIFF
--- a/IRC.md
+++ b/IRC.md
@@ -10,6 +10,7 @@ Lines prefixed with < are sent from client to server, and lines prefixed with > 
 
 You can connect to Twitch IRC using the following bits of information:
 
+- The server name to connect to is: `irc.chat.twitch.tv`.
 - The port to connect to is `6667`
 - SSL is supported on `irc.chat.twitch.tv` on port 443
 - Your nickname must be your Twitch username in lowercase.

--- a/IRC.md
+++ b/IRC.md
@@ -10,13 +10,8 @@ Lines prefixed with < are sent from client to server, and lines prefixed with > 
 
 You can connect to Twitch IRC using the following bits of information:
 
-- The server name to connect to is: `irc.chat.twitch.tv`.
-<<<<<<< 1e79c18b5bb0bf1c30587ae19d751be36730c4e4
 - The port to connect to is `6667`
 - SSL is supported on `irc.chat.twitch.tv` on port 443
-=======
-- The port to connect to is `6667`, or `6697` for SSL.
->>>>>>> SSL support via 6697
 - Your nickname must be your Twitch username in lowercase.
 - Your password should be an OAuth token [authorized through our API](/authentication.md) with the `chat_login` scope.
   - The token must have the prefix of `oauth:`. For example, if you have the token `abcd`, you send `oauth:abcd`.

--- a/IRC.md
+++ b/IRC.md
@@ -63,7 +63,7 @@ A brief list of commands supported by our IRC server include:
 
 **JOIN** *#channel*
 
-Note: After a successful `JOIN`, you will *not* receive a membership state events (`NAMES`, `JOIN`, `PART`, or `MODE`) *unless* you've requested our [IRCv3 `Membership`](#membership) capability
+Note: After a successful `JOIN`, you will *not* receive a membership state events (`NAMES`, `JOIN`, `PART`, or `MODE`) *unless* you've requested our [IRCv3 `Membership`](#membership) capability. The channel name should be entered in lowercase.
 
 ```
 < JOIN #channel

--- a/IRC.md
+++ b/IRC.md
@@ -235,9 +235,10 @@ Adds IRC v3 message tags to `PRIVMSG`, `USERSTATE`, `NOTICE` and `GLOBALUSERSTAT
 Example message:
 
 ```
-> @color=#0D4200;display-name=TWITCH_UserNaME;emotes=25:0-4,12-16/1902:6-10;mod=0;room-id=1337;subscriber=0;turbo=1;user-id=1337;user-type=global_mod :twitch_username!twitch_username@twitch_username.tmi.twitch.tv PRIVMSG #channel :Kappa Keepo Kappa
+> @badges=global_mod/1,turbo/1;color=#0D4200;display-name=TWITCH_UserNaME;emotes=25:0-4,12-16/1902:6-10;mod=0;room-id=1337;subscriber=0;turbo=1;user-id=1337;user-type=global_mod :twitch_username!twitch_username@twitch_username.tmi.twitch.tv PRIVMSG #channel :Kappa Keepo Kappa
 ```
 
+- `badges` is a comma-separated list of chat badges, valid badges are `staff`, `admin`, `global_mod`, `moderator`, `subscriber` and `turbo`.
 - `color` is a hexadecimal RGB color code
   - Empty if it's never been set.
 - `display-name` is the user's display name, escaped [as described in the IRCv3 spec](http://ircv3.net/specs/core/message-tags-3.2.html).

--- a/IRC.md
+++ b/IRC.md
@@ -233,7 +233,7 @@ Adds IRC v3 message tags to `PRIVMSG`, `USERSTATE`, `NOTICE` and `GLOBALUSERSTAT
 Example message:
 
 ```
-> @color=#0D4200;display-name=TWITCH_UserNaME;emotes=25:0-4,12-16/1902:6-10;mod=0;subscriber=0;turbo=1;user-id=1337;user-type=global_mod :twitch_username!twitch_username@twitch_username.tmi.twitch.tv PRIVMSG #channel :Kappa Keepo Kappa
+> @color=#0D4200;display-name=TWITCH_UserNaME;emotes=25:0-4,12-16/1902:6-10;mod=0;room-id=1337;subscriber=0;turbo=1;user-id=1337;user-type=global_mod :twitch_username!twitch_username@twitch_username.tmi.twitch.tv PRIVMSG #channel :Kappa Keepo Kappa
 ```
 
 - `color` is a hexadecimal RGB color code
@@ -245,6 +245,7 @@ Example message:
   - `emote_id` is the number to use in this URL: `http://static-cdn.jtvnw.net/emoticons/v1/:emote_id/:size` (size is 1.0, 2.0 or 3.0)
   - Emote indexes are simply character indexes. `\001ACTION ` does *not* count and indexing starts from the first character that is part of the user's "actual message". In the example message, the first Kappa (emote id 25) is from character 0 (K) to character 4 (a), and the other Kappa is from 12 to 16.
 - `mod`, `subscriber` and `turbo` are either 0 or 1 depending on whether the user has mod, sub or turbo badge or not.
+- `room-id` is the ID of the channel.
 - `user-id` is the user's ID.
 - `user-type` is either *empty*, `mod`, `global_mod`, `admin` or `staff`.
   - The broadcaster can have any of these, including empty.

--- a/IRC.md
+++ b/IRC.md
@@ -11,8 +11,12 @@ Lines prefixed with < are sent from client to server, and lines prefixed with > 
 You can connect to Twitch IRC using the following bits of information:
 
 - The server name to connect to is: `irc.chat.twitch.tv`.
+<<<<<<< 1e79c18b5bb0bf1c30587ae19d751be36730c4e4
 - The port to connect to is `6667`
 - SSL is supported on `irc.chat.twitch.tv` on port 443
+=======
+- The port to connect to is `6667`, or `6697` for SSL.
+>>>>>>> SSL support via 6697
 - Your nickname must be your Twitch username in lowercase.
 - Your password should be an OAuth token [authorized through our API](/authentication.md) with the `chat_login` scope.
   - The token must have the prefix of `oauth:`. For example, if you have the token `abcd`, you send `oauth:abcd`.

--- a/IRC.md
+++ b/IRC.md
@@ -63,7 +63,9 @@ A brief list of commands supported by our IRC server include:
 
 **JOIN** *#channel*
 
-Note: After a successful `JOIN`, you will *not* receive a membership state events (`NAMES`, `JOIN`, `PART`, or `MODE`) *unless* you've requested our [IRCv3 `Membership`](#membership) capability. The channel name should be entered in lowercase.
+Note:
+- After a successful `JOIN`, you will *not* receive a membership state events (`NAMES`, `JOIN`, `PART`, or `MODE`) *unless* you've requested our [IRCv3 `Membership`](#membership) capability.
+- The channel name should be entered in lowercase.
 
 ```
 < JOIN #channel

--- a/v3_resources/streams.md
+++ b/v3_resources/streams.md
@@ -155,6 +155,12 @@ Returns a list of stream objects that are queried by a number of parameters sort
             <td>string</td>
             <td>Only shows streams from a certain type. Permitted values: <code>all</code>, <code>playlist</code>, <code>live</code></td>
         </tr>
+        <tr>
+            <td><code>language</code></td>
+            <td>optional</td>
+            <td>string</td>
+            <td>Only shows streams of a certain language. Permitted values are locale ID strings, e.g. `en`, `fi`, `es-mx`.</td>
+        </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
Channel name lowercase requirement isn't mentioned in the documentation and it's something a lot of people seem to get wrong.

`room-id` was added to PRIVMSG tags, added it to the documentation.

`GET /streams` supports language query parameter.