### PR TITLE
Add help-related message IDs with default message

### DIFF
--- a/IRC.md
+++ b/IRC.md
@@ -193,6 +193,7 @@ unban_success | `target_user` is no longer banned from this room.
 bad_unban_no_ban | `target_user` is not banned from this room.
 already_banned | `target_user` is already banned in this room.
 unrecognized_cmd | Unrecognized command: `command`
+cmds_available | Commands available to you in this room (use /help <command> for details): `command_list`
 usage_me | Usage: "/me <message>" - Send an "emote" message in the third person.
 usage_help | Usage: "/help" - Lists the commands available to you in this room.
 usage_mods | Usage: "/mods" - Lists the moderators of this channel.
@@ -221,6 +222,8 @@ msg_slowmode | This room is in slow mode and you are sending messages too quickl
 msg_duplicate | Your message was not sent because it is identical to the previous one you sent, less than 30 seconds ago.
 msg_emoteonly | This room is in emote only mode. You can find your currently available emoticons using the smiley in the chat text area. See http://link.twitch.tv/emote_only_mode for more information
 no_cheer_badge | You do not have a Cheer badge in this channel.
+room_mods | The moderators of this room are: `mod_list`
+color_changed | Your color has been changed.
 
 ### HOSTTARGET
 

--- a/IRC.md
+++ b/IRC.md
@@ -193,6 +193,29 @@ unban_success | `target_user` is no longer banned from this room.
 bad_unban_no_ban | `target_user` is not banned from this room.
 already_banned | `target_user` is already banned in this room.
 unrecognized_cmd | Unrecognized command: `command`
+usage_me | Usage: "/me <message>" - Send an "emote" message in the third person.
+usage_help | Usage: "/help" - Lists the commands available to you in this room.
+usage_mods | Usage: "/mods" - Lists the moderators of this channel.
+usage_color | Usage: "/color <color>" - Change your username color. Color must be in hex (#000000) or one of the following: Blue, BlueViolet, CadetBlue, Chocolate, Coral, DodgerBlue, Firebrick, GoldenRod, Green, HotPink, OrangeRed, Red, SeaGreen, SpringGreen, YellowGreen.
+usage_ban | Usage: "/ban <username>" - Permanently prevent a user from chatting. Use "unban" to remove a ban.
+usage_unban | Usage: "/unban <username>" - Removes a ban on a user.
+usage_clear | Usage: "/clear" - Clear chat history for all users in this room.
+usage_timeout | Usage: "/timeout <login> [duration]" - Temporarily prevent a user from chatting. Duration (optional, default=600, max=1209600) must be a positive number of seconds. Use "unban" to remove a timeout.
+usage_subscribers | Usage: "/subscribers" - Enables subscribers-only mode (only subscribers may chat in this channel). Use "subscribersoff" to disable.
+usage_subscribersoff | Usage: "/subscribersoff" - Disables subscribers-only mode.
+usage_slow | Usage: "/slow [duration]" - Enables slow mode (limit how often users may send messages). Duration (optional, default=120) must be a positive number of seconds. Use "slowoff" to disable.
+usage_slowoff | Usage: "/slowoff" - Disables slow mode.
+usage_r9kbeta | Usage: "/r9kbeta" - Enables r9k mode. See http://link.twitch.tv/r9k for details. Use "r9kbetaoff" to disable.
+usage_r9kbetaoff | Usage: "/r9kbetaoff" - Disables r9k mode.
+usage_host | Usage: "/host <channel>" - Host another channel. Use "unhost" to unset host mode.
+usage_unhost | Usage: "/unhost" - Stop hosting another channel.
+usage_mod | Usage: "/mod <username>" - Grant mod status to a user. Use "mods" to list the moderators of this room.
+usage_unmod | Usage: "/unmod <username>" - Revoke mod status from a user. Use "mods" to list the moderators of this room.
+usage_commercial | Usage: "/commercial [length]" - Triggers a commercial. Length (optional) must be a positive number of seconds.
+usage_emoteonly | Usage: "/emoteonly" - Enables emote-only mode (only emoticons may be used in chat). Use "emoteonlyoff" to disable.
+usage_emoteonlyoff | Usage: "/emoteonlyoff" - Disables emote-only mode.
+no_help | No help available.
+
 
 
 ### HOSTTARGET

--- a/IRC.md
+++ b/IRC.md
@@ -214,9 +214,13 @@ usage_unmod | Usage: "/unmod <username>" - Revoke mod status from a user. Use "m
 usage_commercial | Usage: "/commercial [length]" - Triggers a commercial. Length (optional) must be a positive number of seconds.
 usage_emoteonly | Usage: "/emoteonly" - Enables emote-only mode (only emoticons may be used in chat). Use "emoteonlyoff" to disable.
 usage_emoteonlyoff | Usage: "/emoteonlyoff" - Disables emote-only mode.
+usage_cheerbadge | Useage: "/cheerbadge" - Toggle the visibility of your Cheer badge in this channel.
 no_help | No help available.
-
-
+msg_subonly | This room is in subscribers only mode. To talk, purchase a channel subscription at http://www.twitch.tv/`channel_name`/subscribe?ref=subscriber_only_mode_chat
+msg_slowmode | This room is in slow mode and you are sending messages too quickly. You will be able to talk again in `cooldown` seconds.
+msg_duplicate | Your message was not sent because it is identical to the previous one you sent, less than 30 seconds ago.
+msg_emoteonly | This room is in emote only mode. You can find your currently available emoticons using the smiley in the chat text area. See http://link.twitch.tv/emote_only_mode for more information
+no_cheer_badge | You do not have a Cheer badge in this channel.
 
 ### HOSTTARGET
 

--- a/IRC.md
+++ b/IRC.md
@@ -225,6 +225,8 @@ no_cheer_badge | You do not have a Cheer badge in this channel.
 room_mods | The moderators of this room are: `mod_list`
 color_changed | Your color has been changed.
 msg_censored_channel | Your message was modified for using words banned by this channel
+cheer_badge_deselected | Cheer badge unequipped.
+cheer_badge_selected | Cheer badge equipped.
 
 ### HOSTTARGET
 

--- a/IRC.md
+++ b/IRC.md
@@ -224,6 +224,7 @@ msg_emoteonly | This room is in emote only mode. You can find your currently ava
 no_cheer_badge | You do not have a Cheer badge in this channel.
 room_mods | The moderators of this room are: `mod_list`
 color_changed | Your color has been changed.
+msg_censored_channel | Your message was modified for using words banned by this channel
 
 ### HOSTTARGET
 


### PR DESCRIPTION
These messages are sent by the IRC server when using `/help [command]` or when providing invalid arguments to a command. `no_help` is used for commands that are registered (listed by `/help`) but don't have a help text, like `/w`.
