### PR TITLE
Remove client_id parameter from /streams

### DIFF
--- a/v3_resources/streams.md
+++ b/v3_resources/streams.md
@@ -144,12 +144,6 @@ Returns a list of stream objects that are queried by a number of parameters sort
             <td>Object offset for pagination. Default is 0.</td>
         </tr>
         <tr>
-            <td><code>client_id</code></td>
-            <td>optional</td>
-            <td>string</td>
-            <td>Only shows streams from applications of <code>client_id</code>.</td>
-        </tr>
-        <tr>
             <td><code>stream_type</code></td>
             <td>optional</td>
             <td>string</td>


### PR DESCRIPTION
Removes the ambiguous client_id parameter from GET /streams since it is listed as optional which is confusing users. I doubt anyone actually uses client_id as currently documented or if it even works anymore.