### PR TITLE
Make PubSub JSON examples valid JSON by removing trailing commas

### DIFF
--- a/PubSub/README.md
+++ b/PubSub/README.md
@@ -14,7 +14,7 @@ These JSON messages differ depending on message/command type but are typically o
 ```json
 {
   "type": "<type_string>",
-  "data": "<json blob>",
+  "data": "<json blob>"
 }
 ```
 
@@ -149,14 +149,14 @@ Once a client has established a connection, they can `LISTEN` on topics they car
   "nonce": "44h1k13746815ab1r2",
   "data": {
     "topics": ["whispers.test_account","video-playback.lirik"],
-    "auth_token": "...",
+    "auth_token": "..."
   }
 }
 // Response from server to client
 {
   "type": "RESPONSE",
   "nonce": "44h1k13746815ab1r2",
-  "error": "",
+  "error": ""
 }
 ```
 

--- a/PubSub/bits.md
+++ b/PubSub/bits.md
@@ -14,7 +14,7 @@ In full, you would send a request that looks like the following:
   "nonce": "...",
   "data": {
     "topics": ["channel-bitsevents.XXXXXXXX"],
-    "auth_token": "...",
+    "auth_token": "..."
   }
 }
 ```

--- a/PubSub/whispers.md
+++ b/PubSub/whispers.md
@@ -14,7 +14,7 @@ In full, you would send a request that looks like the following:
   "nonce": "...",
   "data": {
     "topics": ["whispers.XXXXXXXX"],
-    "auth_token": "...",
+    "auth_token": "..."
   }
 }
 ```


### PR DESCRIPTION
This makes the JSON examples in the PubSub documentation follow the JSON
standard of only having a value-separator (a comma) inbetween object
members and not at the end of the member list

This fixes issue #636 because it seems the websocket servers don't like parsing trailing commas and the documentation examples might as well contain valid JSON.

